### PR TITLE
Added matrix multiplication, `Matrix.rows`, `Matrix.zeros`, and argument checks

### DIFF
--- a/src/crystalla/lib_blas.cr
+++ b/src/crystalla/lib_blas.cr
@@ -1,0 +1,17 @@
+module Crystalla
+  @[Link(framework: "Accelerate")]
+  lib LibBlas
+    enum Order
+      RowMajor = 101
+      ColMajor = 102
+    end
+
+    enum Transpose
+      NoTrans   = 111
+      Trans     = 112
+      ConjTrans = 113
+    end
+
+    fun dgemm = cblas_dgemm(order : Order, transa : Transpose, transb : Transpose, m : Int32, n : Int32, k : Int32, alpha : Float64, a : Float64*, lda : Int32, b : Float64*, ldb : Int32, beta : Float64, c : Float64*, ldc : Int32)
+  end
+end

--- a/src/crystalla/lib_lapack.cr
+++ b/src/crystalla/lib_lapack.cr
@@ -1,7 +1,7 @@
 module Crystalla
   @[Link(framework: "Accelerate")]
   lib LibLapack
-    fun lu = dgetrf_(m: Int32*, n: Int32*, a: Void*, lda: Int32*, ipiv: Int32*, info: Int32*)
-    fun dgetri_(n: Int32*, a: Void*, lda: Int32*, ipiv: Int32*, work: Void*, lwork: Int32*, info: Int32*)
+    fun lu = dgetrf_(m : Int32*, n : Int32*, a : Float64*, lda : Int32*, ipiv : Int32*, info : Int32*)
+    fun dgetri_(n : Int32*, a : Float64*, lda : Int32*, ipiv : Int32*, work : Float64*, lwork : Int32*, info : Int32*)
   end
 end


### PR DESCRIPTION
Added:
- `Matrix#*(other : self)`
- `Matrix.rows(...)`
- `Matrix.zeros(...)`

I also added overloads for matrix creations that accept Number and convert them to floats, so the specs become a bit less noisy. And I include `Crystalla` in spec_helper so there's no need to prefix everything.

Finally, I added some checks so for example if you create a matrix and each column doesn't have the same number of rows an ArgumentError is raised. Or if you invert a non-square matrix you also get an error.
