### PR TITLE
All close matcher

### DIFF
--- a/spec/matrix_spec.cr
+++ b/spec/matrix_spec.cr
@@ -119,7 +119,7 @@ describe Matrix do
       m = Matrix.columns [[1, 3], [2, 4]]
       inverse = Matrix.columns [[-2, 1.5], [1, -0.5]]
 
-      m.invert!.all_close(inverse).should be_true
+      m.invert!.should be_all_close(inverse)
     end
 
     it "raises if non-square" do
@@ -146,7 +146,7 @@ describe Matrix do
         [3*7 + 4*10, 3*8 + 4*11, 3*9 + 4*12],
         [5*7 + 6*10, 5*8 + 6*11, 5*9 + 6*12],
       ]
-      (m1 * m2).all_close(expected).should be_true
+      (m1 * m2).should be_all_close(expected)
     end
 
     it "raises if rows don't match columns" do
@@ -210,7 +210,7 @@ describe Matrix do
       b = Matrix.columns [[1.0, 3.0, 5.0]]
       x = m.solve(b)
       expected = Matrix.columns [[0.3, 0.4, 0.0]]
-      x.all_close(expected).should be_true
+      x.should be_all_close(expected)
     end
 
     it "solves a square system for multiple rhss" do
@@ -218,7 +218,7 @@ describe Matrix do
       b = Matrix.columns [[1.0, 3.0, 5.0], [2.0, 6.0, 10.0]]
       x = m.solve(b)
       expected = Matrix.columns [[0.3, 0.4, 0.0], [0.6, 0.8, 0.0]]
-      x.all_close(expected).should be_true
+      x.should be_all_close(expected)
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,6 @@
 require "spec"
 require "../src/crystalla"
+require "../src/crystalla/spec/*"
 
 include Crystalla
+include Crystalla::Spec::Expectations

--- a/spec/spec_spec.cr
+++ b/spec/spec_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+describe Crystalla::Spec::Expectations do
+  it "should pass all close" do
+    a = Matrix.columns [[1.0, 2.0], [3.0, 4.0]]
+    b = Matrix.columns [[1.0, 2.0], [3.0, 4.00000001]]
+
+    a.should be_all_close(b)
+  end
+
+  it "should fail all close when dimensions are different" do
+    a = Matrix.columns [[1.0, 2.0]]
+    b = Matrix.columns [[1.0, 2.0], [3.0, 5.0]]
+
+    a.should_not be_all_close(b)
+  end
+
+  it "should fail all close when values are different" do
+    a = Matrix.columns [[1.0, 2.0], [3.0, 4.0]]
+    b = Matrix.columns [[1.0, 2.0], [3.0, 5.0]]
+
+    a.should_not be_all_close(b)
+  end
+end

--- a/src/crystalla/spec/expectations.cr
+++ b/src/crystalla/spec/expectations.cr
@@ -1,0 +1,27 @@
+module Crystalla
+  module Spec
+    class AllCloseExpectation(T)
+      def initialize(@m : T)
+      end
+
+      def match(other)
+        @target = other
+        @m.all_close(other)
+      end
+
+      def failure_message
+        "expected:\n#{@m.inspect}\n\ngot:\n#{@target.inspect}"
+      end
+
+      def negative_failure_message
+        "expected not:\n#{@m.inspect}\n\ngot:\n#{@target.inspect}"
+      end
+    end
+
+    module Expectations
+      def be_all_close(value)
+        Spec::AllCloseExpectation.new value
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added `be_all_close` matcher to replace checks of `m1.all_close(m2).should be_true`.
Displays both matrices on failure, rather than `expected true, got false`.
