### PR TITLE
Implemented sum

### DIFF
--- a/spec/matrix_spec.cr
+++ b/spec/matrix_spec.cr
@@ -164,6 +164,54 @@ describe Matrix do
     end
   end
 
+  context "+" do
+    it "adds two matrices" do
+      m1 = Matrix.rows [
+             [1, 2],
+             [3, 4],
+             [5, 6],
+           ]
+      m2 = Matrix.rows [
+             [7, 8],
+             [9, 10],
+             [11, 12],
+           ]
+      expected = Matrix.rows [
+                   [8, 10],
+                   [12, 14],
+                   [16, 18],
+                 ]
+      (m1 + m2).all_close(expected).should be_true
+    end
+
+    it "raises if rows don't match" do
+      m1 = Matrix.rows [
+             [1, 2],
+           ]
+      m2 = Matrix.rows [
+             [7, 8],
+             [8, 9],
+           ]
+      expect_raises ArgumentError do
+        m1 + m2
+      end
+    end
+
+    it "raises if cols don't match" do
+      m1 = Matrix.rows [
+             [1, 2],
+             [1, 2],
+           ]
+      m2 = Matrix.rows [
+             [7, 8, 10],
+             [8, 9, 10],
+           ]
+      expect_raises ArgumentError do
+        m1 + m2
+      end
+    end
+  end
+
   context "add rows" do
     it "adds a row at the beginning" do
       m = Matrix.columns [[1.0, 3.0], [2.0, 4.0]]

--- a/src/crystalla/matrix.cr
+++ b/src/crystalla/matrix.cr
@@ -49,6 +49,17 @@ module Crystalla
       values[number_of_rows * j + i] = x
     end
 
+    def +(other : self)
+      raise ArgumentError.new "number of rows mismatch in matrix addition" if number_of_rows != other.number_of_rows
+      raise ArgumentError.new "number of columns mismatch in matrix addition" if number_of_cols != other.number_of_cols
+
+      added = Array.new(number_of_rows * number_of_cols, 0.0)
+      values.size.times do |i|
+        added[i] = values[i] + other.values[i]
+      end
+      Matrix.new(added, number_of_rows, number_of_cols)
+    end
+
     def *(other : self)
       if number_of_cols != other.number_of_rows
         raise ArgumentError.new "number of rows/columns mismatch in matrix multiplication"


### PR DESCRIPTION
Manually sums all values. 

Note that the following implementation using BLAS dgemm is roughly 5 times slower (tested with matrices of 1000 x 1000).

``` crystal
    def +(other : self)
      c = other.clone
      eye = Matrix.eye(number_of_cols)
      LibBlas.dgemm(
        LibBlas::Order::ColMajor,                                 # order
        LibBlas::Transpose::NoTrans, LibBlas::Transpose::NoTrans, # transa, transb
        number_of_rows, number_of_cols, number_of_cols,           # m, n, k
        1.0, self, ld,                                            # alpha, a, lda
        eye, eye.ld,                                              # b, ldb
        1.0, c, c.ld                                              # beta, c, ldc
      )
      c
    end
```
