### PR TITLE
Nicer `Matrix#to_s`, and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,26 @@ require "crystalla"
 # Matrixes are created from column arrays
 m = Crystalla::Matrix.columns [[1.0, 2.0], [3.0, 4.0]]
 
-p "This is how M looks now: "
-m.print
+puts "This is how M looks now: "
+puts m
+puts
 
-p "This is M's inverse (note it's inverted in place): "
+puts "This is M's inverse (note it's inverted in place): "
 m.invert!
-m.print
-
-# => "This is how M looks now: "
-# => "| 1  3 |"
-# => "| 2  4 |"
-# => "This is M's inverse (note it's inverted in place): "
-# => "| -2  1.5 |"
-# => "| 1  -0.5 |"
+puts m
 ```
+
+Output:
+
+```text
+This is how M looks now:
+Matrix[[ 1, 3 ],
+       [ 2, 4 ]]
+
+This is M's inverse (note it's inverted in place):
+Matrix[[ -2,  1.5 ],
+       [  1, -0.5 ]]
+ ```
 
 ## Features implemented so far
 

--- a/spec/matrix_spec.cr
+++ b/spec/matrix_spec.cr
@@ -101,6 +101,18 @@ describe Matrix do
         (value - value.to_i).should be_close(0, 0.0000001)
       end
     end
+
+    it "creates with #[]" do
+      m = Matrix[
+        [1, 2],
+        [3, 4],
+      ]
+
+      m[0, 0].should eq(1)
+      m[0, 1].should eq(2)
+      m[1, 0].should eq(3)
+      m[1, 1].should eq(4)
+    end
   end
 
   context "dimensions" do
@@ -309,6 +321,44 @@ describe Matrix do
     it "transposes" do
       m = Matrix.rows [[1,2,3],[3,2,1]]
       m.transpose.should eq(Matrix.columns [[1,2,3],[3,2,1]])
+    end
+  end
+
+  context "to_s" do
+    it "with integers" do
+      Matrix[
+        [1, 2],
+        [3, 4],
+      ].to_s.should eq(
+        <<-STR
+Matrix[[ 1, 2 ],
+       [ 3, 4 ]]
+STR
+      )
+    end
+
+    it "with integers of different sizes" do
+      Matrix[
+        [10, 2],
+        [3, 40],
+      ].to_s.should eq(
+        <<-STR
+Matrix[[ 10,  2 ],
+       [  3, 40 ]]
+STR
+      )
+    end
+
+    it "with floats of different sizes" do
+      Matrix[
+        [10.1, 2.123],
+        [3.45, 40.1],
+      ].to_s.should eq(
+        <<-STR
+Matrix[[ 10.1 ,  2.123 ],
+       [  3.45, 40.1   ]]
+STR
+      )
     end
   end
 end


### PR DESCRIPTION
This changes `Matrix#to_s` so that numbers are nicely formatted according to the number's length and the position of the decimal dot. I also updated the README to use `puts` and show the output.

The output of `Matrix#to_s` is valid Crystal code, so you can copy/paste it and run it. For this I added the `Matrix.[]` method which is like `Matrix.rows` but shorter.
