### PR TITLE
Add trace function

### DIFF
--- a/spec/matrix_spec.cr
+++ b/spec/matrix_spec.cr
@@ -403,6 +403,20 @@ describe Matrix do
     end
   end
 
+  context "trace" do
+    it "computes trace for floats" do
+      m = Matrix.rows([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]])
+      m.trace.should eq(16.5) # 1.1 + 5.5 + 9.9
+    end
+
+    it "raises an error when matrix isn't square" do
+      a = Matrix.rows([[1, 2, 3, 4], [5, 6, 7, 8]])
+      expect_raises ArgumentError, "Number of rows (2) does not match number of columns (4)" do
+        a.trace
+      end
+    end
+  end
+
   context "to_s" do
     it "with integers" do
       Matrix[

--- a/src/crystalla/matrix.cr
+++ b/src/crystalla/matrix.cr
@@ -341,6 +341,12 @@ module Crystalla
       s
     end
 
+    # Returns the sum of the diagonal elements. Only useful for numeric matrices.
+    def trace : Float64
+      raise ArgumentError.new "Number of rows (#{number_of_rows}) does not match number of columns (#{number_of_cols})" unless square?
+      (0...number_of_cols).sum(0.0) { |i| self[i, i] }
+    end
+
     private def self.check_columns_have_same_number_of_rows(columns)
       return if columns.empty?
 


### PR DESCRIPTION
Hi,

I hope you don't mind unsolicited pull requests.  I pretty much just grabbed this from the main Crystal Matrix class: https://github.com/manastech/crystal/blob/master/src/matrix.cr#L691

I didn't immediately see a way to compute the trace using lapack, and since it's just adding n numbers together (for an n x n matrix) I think performance probably isn't a big deal.  But let me know if you have any comments or questions.  Thanks!
