### PR TITLE
Fix `Matrix#to_s` when ints and floats are present

### DIFF
--- a/spec/matrix_spec.cr
+++ b/spec/matrix_spec.cr
@@ -439,6 +439,18 @@ Matrix[[ 10.1 ,  2.123 ],
 STR
       )
     end
+
+    it "with int and floats" do
+      Matrix[
+        [1, 2],
+        [0.1, 0.2],
+      ].to_s.should eq(
+        <<-STR
+Matrix[[ 1  , 2   ],
+       [ 0.1, 0.2 ]]
+STR
+      )
+    end
   end
 
   context "observers (as in Algebraic Data Types, not the pattern!)" do

--- a/src/crystalla/matrix.cr
+++ b/src/crystalla/matrix.cr
@@ -311,7 +311,10 @@ module Crystalla
           io << str
 
           # Apply padding to the right of the dot
-          (info_right - right).times { io << " " }
+          right_padding = info_right - right
+          # Add one if the current number doesn't have a dot but the maximum does
+          right_padding += 1 if right == 0 && info_right > 0
+          right_padding.times { io << " " }
         end
         io << " ]"
       end


### PR DESCRIPTION
There was a case where `to_s` didn't work well.
